### PR TITLE
ACE Uncon

### DIFF
--- a/addons/medical/CfgFunctions.hpp
+++ b/addons/medical/CfgFunctions.hpp
@@ -8,3 +8,8 @@ class CfgFunctions {
         };
     };
 };
+class ACE_Medical_StateMachine {
+    class Unconscious {
+        onState = QPATHTOF(functions\fnc_handleStateUnconsciousHijack.sqf);
+    };
+};

--- a/addons/medical/XEH_PREP.hpp
+++ b/addons/medical/XEH_PREP.hpp
@@ -1,2 +1,3 @@
 PREP(treatment);
+PREP(handleStateUnconscious);
 PREP(handleSurgicalKit);

--- a/addons/medical/config.cpp
+++ b/addons/medical/config.cpp
@@ -5,7 +5,7 @@ class CfgPatches {
         units[] = {};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"qte_ace_main", "ace_medical_treatment"};
+        requiredAddons[] = {"qte_ace_main", "ace_medical_treatment", "ace_medical_statemachine"};
         author = "diwako";
         url = "https://github.com/diwako/qte_ace";
         authorUrl = "https://github.com/diwako/qte_ace";

--- a/addons/medical/functions/fnc_handleStateUnconscious.sqf
+++ b/addons/medical/functions/fnc_handleStateUnconscious.sqf
@@ -1,0 +1,46 @@
+// copy from ACE medical, modified for QTE ACE and KAT support.
+#include "\z\ace\addons\medical_statemachine\script_component.hpp"
+
+
+params ["_unit"];
+
+// If the unit died the loop is finished
+if (!alive _unit || {!local _unit}) exitWith {};
+
+[_unit] call EFUNC(medical_vitals,handleUnitVitals);
+
+// Handle spontaneous wake up from unconsciousness
+if (EGVAR(medical,spontaneousWakeUpChance) > 0) then {
+    if (_unit call EFUNC(medical_status,hasStableVitals)) then {
+        systemChat format ["%1 STABLE %2", _unit, CBA_missionTime];
+        private _lastWakeUpCheck = _unit getVariable QEGVAR(medical,lastWakeUpCheck);
+
+        // Handle setting being changed mid-mission and still properly check
+        // already unconscious units, should handle locality changes as well
+        if (isNil "_lastWakeUpCheck") exitWith {
+            TRACE_1("undefined lastWakeUpCheck: setting to current time",_lastWakeUpCheck);
+            _unit setVariable [QEGVAR(medical,lastWakeUpCheck), CBA_missionTime];
+        };
+
+        private _wakeUpCheckInterval = SPONTANEOUS_WAKE_UP_INTERVAL;
+        if (EGVAR(medical,spontaneousWakeUpEpinephrineBoost) > 1) then {
+            private _epiEffectiveness = ([_unit, "Epinephrine", false] call EFUNC(medical_status,getMedicationCount)) select 1;
+            _wakeUpCheckInterval = _wakeUpCheckInterval * linearConversion [0, 1, _epiEffectiveness, 1, 1 / EGVAR(medical,spontaneousWakeUpEpinephrineBoost), true];
+            TRACE_2("epiBoost",_epiEffectiveness,_wakeUpCheckInterval);
+        };
+        if (CBA_missionTime - _lastWakeUpCheck > _wakeUpCheckInterval) then {
+            TRACE_2("Checking for wake up",_unit,EGVAR(medical,spontaneousWakeUpChance));
+            _unit setVariable [QEGVAR(medical,lastWakeUpCheck), CBA_missionTime];
+
+            if (random 1 <= EGVAR(medical,spontaneousWakeUpChance)) then {
+                TRACE_1("Spontaneous wake up!",_unit);
+                [QEGVAR(medical,WakeUp), _unit] call CBA_fnc_localEvent;
+            };
+        };
+    } else {
+        // Unstable vitals, procrastinate the next wakeup check
+        private _lastWakeUpCheck = _unit getVariable [QEGVAR(medical,lastWakeUpCheck), 0];
+        _unit setVariable [QEGVAR(medical,lastWakeUpCheck), _lastWakeUpCheck max CBA_missionTime];
+       systemChat format ["%1 UNSTABLE %2", _unit, CBA_missionTime];
+    };
+};

--- a/addons/medical/functions/fnc_handleStateUnconsciousHijack.sqf
+++ b/addons/medical/functions/fnc_handleStateUnconsciousHijack.sqf
@@ -1,0 +1,3 @@
+#include "..\script_component.hpp"
+// only doing this so i can use prep compile flags and do not need to deal with cfgfunctions recompile ones
+_this call FUNC(handleStateUnconscious);

--- a/include/z/ace/addons/medical_engine/script_component.hpp
+++ b/include/z/ace/addons/medical_engine/script_component.hpp
@@ -1,0 +1,42 @@
+#define COMPONENT medical_engine
+#define COMPONENT_BEAUTIFIED Medical Engine
+#include "\z\ace\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_MEDICAL_ENGINE
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_MEDICAL_ENGINE
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_MEDICAL_ENGINE
+#endif
+
+#include "\z\ace\addons\medical_engine\script_macros_medical.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
+#include "\z\ace\addons\medical_engine\script_macros_config.hpp"
+
+#define PRELOAD_CLASS(class) \
+    TRACE_1("Starting preload",class);\
+    [{\
+        1 preloadObject _this;\
+    }, {\
+        TRACE_1("Preload done",_this);\
+    }, class] call CBA_fnc_waitUntilAndExecute
+
+#define PRIORITY_HEAD       3
+#define PRIORITY_BODY       4
+#define PRIORITY_LEFT_ARM   (1 + random 1)
+#define PRIORITY_RIGHT_ARM  (1 + random 1)
+#define PRIORITY_LEFT_LEG   (1 + random 1)
+#define PRIORITY_RIGHT_LEG  (1 + random 1)
+#define PRIORITY_STRUCTURAL 1
+
+// don't change, these reflect hard coded engine behaviour
+#define DAMAGED_MIN_THRESHOLD 0.45
+#define LIMPING_MIN_DAMAGE 0.5
+
+#define UNCON_ANIM(var1) DOUBLES(GVAR(uncon_anim),var1)
+#define QUNCON_ANIM(var1) QUOTE(UNCON_ANIM(var1))

--- a/include/z/ace/addons/medical_engine/script_macros_medical.hpp
+++ b/include/z/ace/addons/medical_engine/script_macros_medical.hpp
@@ -1,0 +1,225 @@
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#define ALL_BODY_PARTS ["head", "body", "leftarm", "rightarm", "leftleg", "rightleg"]
+#define ALL_SELECTIONS ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"]
+#define ALL_HITPOINTS ["HitHead", "HitChest", "HitLeftArm", "HitRightArm", "HitLeftLeg", "HitRightLeg"]
+
+#define HITPOINT_INDEX_HEAD 0
+#define HITPOINT_INDEX_BODY 1
+#define HITPOINT_INDEX_LARM 2
+#define HITPOINT_INDEX_RARM 3
+#define HITPOINT_INDEX_LLEG 4
+#define HITPOINT_INDEX_RLEG 5
+
+// Damage threshold above which fatal organ damage can occur
+#define HEAD_DAMAGE_THRESHOLD EGVAR(medical,const_headDamageThreshold)
+#define HEAD_DAMAGE_THRESHOLD_DEFAULT 1
+#define ORGAN_DAMAGE_THRESHOLD EGVAR(medical,const_organDamageThreshold)
+#define ORGAN_DAMAGE_THRESHOLD_DEFAULT 0.6
+// Consts for determineIfFatal: sum of damage (values are calcualted at runtime in preInit)
+#define FATAL_SUM_DAMAGE_WEIBULL_K EGVAR(medical,const_fatalSumDamageWeibull_K)
+#define FATAL_SUM_DAMAGE_WEIBULL_L EGVAR(medical,const_fatalSumDamageWeibull_L)
+
+// Chance to hit heart based on ratio of 70kg (approx. 70L) body to 70mL stroke volume of heart
+// Assuming torso is 50% of the body volume (35L)
+#define HEART_HIT_CHANCE EGVAR(medical,const_heartHitChance)
+#define HEART_HIT_CHANCE_DEFAULT 0.05
+
+#define MEDICAL_ACTION_DISTANCE 1.75
+
+// scale received pain to 0-2 level to select type of scream
+// below 0.25: 0, from 0.25 to 0.5: 1, more than 0.5: 2
+#define PAIN_TO_SCREAM(pain) (floor (4 * pain) min 2)
+
+// scale received pain to 0-2 level to select type of scream
+// below 0.33: 0, from 0.34 to 0.66: 1, more than 0.67: 2
+#define PAIN_TO_MOAN(pain) (floor (3 * pain) min 2)
+
+#define GET_NUMBER(config,default) (if (isNumber (config)) then {getNumber (config)} else {default})
+#define GET_STRING(config,default) (if (isText (config)) then {getText (config)} else {default})
+#define GET_ARRAY(config,default) (if (isArray (config)) then {getArray (config)} else {default})
+
+#define DEFAULT_HEART_RATE 80
+#define DEFAULT_SPO2 97
+#define DEFAULT_PERIPH_RES 100
+
+// --- blood
+// 0.077 l/kg * 80kg = 6.16l
+#define DEFAULT_BLOOD_VOLUME 6.0 // in liters
+
+#define BLOOD_VOLUME_CLASS_1_HEMORRHAGE 6.000 // lost less than 15% blood, Class I Hemorrhage
+#define BLOOD_VOLUME_CLASS_2_HEMORRHAGE 5.100 // lost more than 15% blood, Class II Hemorrhage
+#define BLOOD_VOLUME_CLASS_3_HEMORRHAGE 4.200 // lost more than 30% blood, Class III Hemorrhage
+#define BLOOD_VOLUME_CLASS_4_HEMORRHAGE 3.600 // lost more than 40% blood, Class IV Hemorrhage
+// Lost more than 50% blood, Unrecoverable
+#define BLOOD_VOLUME_FATAL 3.0
+
+// Minimum blood volume, in liters, for a patient to have the chance to wake up
+#define MINIMUM_BLOOD_FOR_STABLE_VITALS EGVAR(medical,const_stableVitalsBloodThreshold)
+#define MINIMUM_BLOOD_FOR_STABLE_VITALS_DEFAULT BLOOD_VOLUME_CLASS_2_HEMORRHAGE
+
+// IV Change per second calculation:
+// 250 ml should take 60 seconds to fill. 250 ml / 60 s ~ 4.1667 ml/s.
+#define IV_CHANGE_PER_SECOND 4.1667 // in milliliters per second
+
+// Minimum amount of damage required for penetrating wounds (also minDamage for velocity wounds)
+#define PENETRATION_THRESHOLD EGVAR(medical,const_penetrationThreshold)
+#define PENETRATION_THRESHOLD_DEFAULT 0.35
+
+// To be replaced by a proper blood pressure calculation
+#define BLOOD_LOSS_KNOCK_OUT_THRESHOLD EGVAR(medical,const_bloodLossKnockOutThreshold)
+#define BLOOD_LOSS_KNOCK_OUT_THRESHOLD_DEFAULT 0.5 // 50% of cardiac output
+
+// Used to color interaction icons and body image selections
+#define BLOOD_LOSS_RED_THRESHOLD 0.5
+#define BLOOD_LOSS_TOTAL_COLORS 10
+#define DAMAGE_BLUE_THRESHOLD 0.8
+#define DAMAGE_TOTAL_COLORS 10
+
+// Qualitative bleed rate thresholds as a fraction of knock out blood loss
+// Note that half of knock out blood loss is considered unstable, and knock out blood loss is considered critical
+#define BLEED_RATE_SLOW 0.1 // Slow - One fifth of unstable blood loss
+#define BLEED_RATE_MODERATE 0.5 // Moderate - Vitals considered stable
+#define BLEED_RATE_SEVERE 1.0 // Severe - Vitals considered unstable
+// Massive - Vitals considered critical
+
+// Pain above which a unit can go unconscious upon receiving damage
+#define PAIN_UNCONSCIOUS EGVAR(medical,painUnconsciousThreshold)
+
+// Pain fade out time (time it takes until pain is guaranteed to be completly gone)
+#define PAIN_FADE_TIME EGVAR(medical,const_painFadeTime)
+#define PAIN_FADE_TIME_DEFAULT 900
+
+// Only relevant when advanced medication is disabled
+// Morphine pain suppression fade out time (time it takes until pain suppression is guaranteed to be completly gone)
+#define PAIN_SUPPRESSION_FADE_TIME 1800
+
+// Chance to wake up when vitals are stable (checked once every SPONTANEOUS_WAKE_UP_INTERVAL seconds)
+#define SPONTANEOUS_WAKE_UP_INTERVAL EGVAR(medical,const_wakeUpCheckInterval)
+#define SPONTANEOUS_WAKE_UP_INTERVAL_DEFAULT 15
+
+// Minimum leg damage required for limping
+#define LIMPING_DAMAGE_THRESHOLD EGVAR(medical,const_limpingDamageThreshold)
+#define LIMPING_DAMAGE_THRESHOLD_DEFAULT 0.30
+
+// Minimum limb damage required for fracture
+#define FRACTURE_DAMAGE_THRESHOLD EGVAR(medical,const_fractureDamageThreshold)
+#define FRACTURE_DAMAGE_THRESHOLD_DEFAULT 0.50
+
+// Minimum cardiac output
+#define CARDIAC_OUTPUT_MIN EGVAR(medical,const_minCardiacOutput)
+#define CARDIAC_OUTPUT_MIN_DEFAULT 0.05
+
+// Minimum body part damage required for blood effect on uniform
+#define VISUAL_BODY_DAMAGE_THRESHOLD 0.35
+
+// Empty wound data, used for some default return values
+// [classID, amountOf, bloodloss, damage]
+#define EMPTY_WOUND [-1, 0, 0, 0]
+
+// Base time to bandage each wound category
+#define BANDAGE_TIME_S 4
+#define BANDAGE_TIME_M 6
+#define BANDAGE_TIME_L 8
+#define BANDAGE_TIME_MOD_MEDIC -2
+#define BANDAGE_TIME_MOD_SELF 4
+
+#define DEFAULT_BANDAGE_REOPENING_CHANCE 0.1
+#define DEFAULT_BANDAGE_REOPENING_MIN_DELAY 120
+#define DEFAULT_BANDAGE_REOPENING_MAX_DELAY 200
+
+#define DEFAULT_TOURNIQUET_VALUES [0,0,0,0,0,0]
+
+// Time until a tourniquet starts causing pain
+#define TOURNIQUET_MIN_TIME_FOR_PAIN 120
+
+// How much pain a tourniquet will cause per second after TOURNIQUET_MIN_TIME_FOR_PAIN
+#define TOURNIQUET_PAIN_PER_SECOND 0.001
+
+#define DEFAULT_FRACTURE_VALUES [0,0,0,0,0,0]
+
+#define DEFAULT_BODYPART_DAMAGE_VALUES [0,0,0,0,0,0]
+
+// Triage colors, for consistency across UIs and functions
+#define TRIAGE_COLOR_NONE      0, 0, 0, 0.9
+#define TRIAGE_COLOR_MINIMAL   0, 0.5, 0, 0.9
+#define TRIAGE_COLOR_DELAYED   1, 0.84, 0, 0.9
+#define TRIAGE_COLOR_IMMEDIATE 1, 0, 0, 0.9
+#define TRIAGE_COLOR_DECEASED  0, 0, 0, 0.9
+
+#define TRIAGE_TEXT_COLOR_NONE      1, 1, 1, 1
+#define TRIAGE_TEXT_COLOR_MINIMAL   1, 1, 1, 1
+#define TRIAGE_TEXT_COLOR_DELAYED   0, 0, 0, 1
+#define TRIAGE_TEXT_COLOR_IMMEDIATE 1, 1, 1, 1
+#define TRIAGE_TEXT_COLOR_DECEASED  1, 1, 1, 1
+
+// Medical activity logs
+#define MED_LOG_MAX_ENTRIES 8
+#define MED_LOG_VARNAME(type) (format [QEGVAR(medical,log_%1), type])
+
+// - Unit Variables ----------------------------------------------------
+// These variables get stored in object space and used across components
+// Defined here for easy consistency with GETVAR/SETVAR (also a list for reference)
+#define VAR_BLOOD_PRESS       QEGVAR(medical,bloodPressure)
+#define VAR_BLOOD_VOL         QEGVAR(medical,bloodVolume)
+#define VAR_WOUND_BLEEDING    QEGVAR(medical,woundBleeding)
+#define VAR_CRDC_ARRST        QEGVAR(medical,inCardiacArrest)
+#define VAR_HEART_RATE        QEGVAR(medical,heartRate)
+#define VAR_SPO2              QEGVAR(medical,spo2)
+#define VAR_OXYGEN_DEMAND     QEGVAR(medical,oxygenDemand)
+#define VAR_PAIN              QEGVAR(medical,pain)
+#define VAR_PAIN_SUPP         QEGVAR(medical,painSuppress)
+#define VAR_PERIPH_RES        QEGVAR(medical,peripheralResistance)
+#define VAR_UNCON             "ACE_isUnconscious"
+#define VAR_OPEN_WOUNDS       QEGVAR(medical,openWounds)
+#define VAR_BANDAGED_WOUNDS   QEGVAR(medical,bandagedWounds)
+#define VAR_STITCHED_WOUNDS   QEGVAR(medical,stitchedWounds)
+#define VAR_BODYPART_DAMAGE   QEGVAR(medical,bodyPartDamage)
+// These variables track gradual adjustments (from medication, etc.)
+#define VAR_MEDICATIONS       QEGVAR(medical,medications)
+// These variables track the current state of status values above
+#define VAR_HEMORRHAGE        QEGVAR(medical,hemorrhage)
+#define VAR_IN_PAIN           QEGVAR(medical,inPain)
+#define VAR_TOURNIQUET        QEGVAR(medical,tourniquets)
+#define VAR_FRACTURES         QEGVAR(medical,fractures)
+
+// - Unit Functions ---------------------------------------------------
+// Retrieval macros for common unit values
+// Defined for easy consistency and speed
+#define GET_SM_STATE(_unit)         ([_unit, EGVAR(medical,STATE_MACHINE)] call CBA_statemachine_fnc_getCurrentState)
+#define GET_BLOOD_VOLUME(unit)      (unit getVariable [VAR_BLOOD_VOL, DEFAULT_BLOOD_VOLUME])
+#define GET_WOUND_BLEEDING(unit)    (unit getVariable [VAR_WOUND_BLEEDING, 0])
+#define GET_HEART_RATE(unit)        (unit getVariable [VAR_HEART_RATE, DEFAULT_HEART_RATE])
+#define GET_SPO2(unit)              (unit getVariable [VAR_SPO2, DEFAULT_SPO2])
+#define GET_HEMORRHAGE(unit)        (unit getVariable [VAR_HEMORRHAGE, 0])
+#define GET_PAIN(unit)              (unit getVariable [VAR_PAIN, 0])
+#define GET_PAIN_SUPPRESS(unit)     (unit getVariable [VAR_PAIN_SUPP, 0])
+#define GET_TOURNIQUETS(unit)       (unit getVariable [VAR_TOURNIQUET, DEFAULT_TOURNIQUET_VALUES])
+#define GET_FRACTURES(unit)         (unit getVariable [VAR_FRACTURES, DEFAULT_FRACTURE_VALUES])
+#define IN_CRDC_ARRST(unit)         (unit getVariable [VAR_CRDC_ARRST, false])
+#define IS_BLEEDING(unit)           (GET_WOUND_BLEEDING(unit) > 0)
+#define IS_IN_PAIN(unit)            (unit getVariable [VAR_IN_PAIN, false])
+#define IS_UNCONSCIOUS(unit)        (unit getVariable [VAR_UNCON, false])
+#define GET_OPEN_WOUNDS(unit)       (unit getVariable [VAR_OPEN_WOUNDS, createHashMap])
+#define GET_BANDAGED_WOUNDS(unit)   (unit getVariable [VAR_BANDAGED_WOUNDS, createHashMap])
+#define GET_STITCHED_WOUNDS(unit)   (unit getVariable [VAR_STITCHED_WOUNDS, createHashMap])
+#define GET_DAMAGE_THRESHOLD(unit)  (unit getVariable [QEGVAR(medical,damageThreshold), [EGVAR(medical,AIDamageThreshold),EGVAR(medical,playerDamageThreshold)] select (isPlayer unit)])
+#define GET_BODYPART_DAMAGE(unit)   (unit getVariable [VAR_BODYPART_DAMAGE, DEFAULT_BODYPART_DAMAGE_VALUES])
+
+// The following function calls are defined here just for consistency
+#define GET_BLOOD_LOSS(unit)        ([unit] call EFUNC(medical_status,getBloodLoss))
+#define GET_BLOOD_PRESSURE(unit)    ([unit] call EFUNC(medical_status,getBloodPressure))
+
+// Derivative unit values commonly used
+#define GET_PAIN_PERCEIVED(unit)    (0 max (GET_PAIN(unit) - GET_PAIN_SUPPRESS(unit)) min 1)
+
+#define HAS_TOURNIQUET_APPLIED_ON(unit,index) ((GET_TOURNIQUETS(unit) select index) > 0)
+
+// Cache expiry values, in seconds
+#define IN_MEDICAL_FACILITY_CACHE_EXPIRY 1
+#define CAN_TREAT_CONDITION_CACHE_EXPIRY 2
+
+// Ignore UAV/Drone AI Base Classes
+#define IGNORE_BASE_UAVPILOTS "B_UAV_AI", "O_UAV_AI", "UAV_AI_base_F"

--- a/include/z/ace/addons/medical_statemachine/script_component.hpp
+++ b/include/z/ace/addons/medical_statemachine/script_component.hpp
@@ -1,0 +1,22 @@
+#define COMPONENT medical_statemachine
+#define COMPONENT_BEAUTIFIED Medical State Machine
+#include "\z\ace\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_MEDICAL_STATEMACHINE
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_MEDICAL_STATEMACHINE
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_MEDICAL_STATEMACHINE
+#endif
+
+#include "\z\ace\addons\medical_engine\script_macros_medical.hpp"
+#include "\z\ace\addons\main\script_macros.hpp"
+
+#define FATAL_INJURIES_ALWAYS 0
+#define FATAL_INJURIES_CRDC_ARRST 1
+#define FATAL_INJURIES_NEVER 2


### PR DESCRIPTION
Ref #27 
Trying to figure out how to override the uncon in state machine

get relatively useless error atm
```
 8:39:14 Error in expression <\z\qte_ace\addons\medical\functions\fnc_>
 8:39:14   Error position: <\z\qte_ace\addons\medical\functions\fnc_>
 8:39:14   Error Invalid number in expression
 8:39:14  ➥ Context: 	[] L6 (x\cba\addons\xeh\fnc_initDisplay3DEN.sqf)
	[] L8 (x\cba\addons\xeh\fnc_initDisplay3DEN.sqf)
	[] L160 (x\cba\addons\xeh\fnc_preInit.sqf)
	[] L119 (x\cba\addons\xeh\fnc_preInit.sqf)
	[] L120 (x\cba\addons\xeh\fnc_preInit.sqf)
	[] L121 (x\cba\addons\xeh\fnc_preInit.sqf)
	[] L124 (x\cba\addons\xeh\fnc_preInit.sqf)
	[] L1 ()
	[] L11 (z\ace\addons\medical_statemachine\XEH_preInit.sqf)
	[] L40 (x\cba\addons\statemachine\fnc_createFromConfig.sqf)
	[] L35 (x\cba\addons\statemachine\fnc_createFromConfig.sqf)
	[] L35 (x\cba\addons\statemachine\fnc_createFromConfig.sqf)
```